### PR TITLE
fixes_flash_helper_for_rails_4_1

### DIFF
--- a/app/helpers/bootstrap_rails_helpers/flash_helper.rb
+++ b/app/helpers/bootstrap_rails_helpers/flash_helper.rb
@@ -13,7 +13,7 @@ module BootstrapRailsHelpers::FlashHelper
     flash.each do |type, message|
       # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
       next if message.blank?
-    
+      type = type.to_sym
       type = :success if type == :notice
       type = :error   if type == :alert
       next unless ALERT_TYPES.include?(type)


### PR DESCRIPTION
I see that in Rails 4.1 (in my case 4.1.6)  flash that was made by controller
redirect_to(new_user_friend_assignment_path,: {info: "Чтобы создать беседу добавьте собеседников"})
p flash # => #<ActionDispatch::Flash::FlashHash:0x00000007e9b748 @discard=#<Set: {"info"}>, @flashes=   {"info"=>"Чтобы создать беседу добавьте собеседников"}, @now=nil>

It's means that ALERT_TYPES.include?(type) always returns false (because "info" - is a string, not symbol)

PS: sorry for my english
