### PR TITLE
Add raw method to flash

### DIFF
--- a/app/views/bootstrap_rails_helpers/_flash_alert.html.erb
+++ b/app/views/bootstrap_rails_helpers/_flash_alert.html.erb
@@ -1,4 +1,4 @@
 <div class="alert fade in<% if alert_type %> alert-<%= alert_type.to_s.parameterize %><% end %>">
   <button type="button" class="close" data-dismiss="alert">&times;</button>
-  <%= message %>
+  <%= raw(message) %>
 </div>


### PR DESCRIPTION
when we try to use html in flash messages like this:

```
Пароль не подошел.  <a href="/html/gmail_instruction.html" target="blank">Информация для пользователей Gmail</a>
```

we see in brouser same message (string with "<", ">", etc.) instead of:
Пароль не подошел.  <a href="/html/gmail_instruction.html" target="blank">Информация для пользователей Gmail</a>
